### PR TITLE
Support `GCE_METADATA_HOST`

### DIFF
--- a/oauth2client/__init__.py
+++ b/oauth2client/__init__.py
@@ -14,7 +14,7 @@
 
 """Client library for using OAuth2, especially with Google APIs."""
 
-__version__ = '4.1.4'
+__version__ = '4.1.5'
 
 GOOGLE_AUTH_URI = 'https://accounts.google.com/o/oauth2/v2/auth'
 GOOGLE_DEVICE_URI = 'https://oauth2.googleapis.com/device/code'

--- a/oauth2client/contrib/_metadata.py
+++ b/oauth2client/contrib/_metadata.py
@@ -29,10 +29,14 @@ from oauth2client import client
 from oauth2client import transport
 
 
-
-_GCE_METADATA_HOST = os.getenv('GCE_METADATA_HOST', os.getenv(
+# GCE_METADATA_HOST was originally named GCE_METADATA_ROOT.
+# Check the new variable first and fall back to the old one
+# if it is not present.
+_GCE_METADATA_HOST = os.getenv('GCE_METADATA_HOST')
+if not _GCE_METADATA_HOST:
+    _GCE_METADATA_HOST = os.getenv(
         'GCE_METADATA_ROOT', "metadata.google.internal"
-    ))
+    )
 
 METADATA_ROOT = 'http://{}/computeMetadata/v1/'.format(
     _GCE_METADATA_HOST)

--- a/oauth2client/contrib/_metadata.py
+++ b/oauth2client/contrib/_metadata.py
@@ -29,8 +29,13 @@ from oauth2client import client
 from oauth2client import transport
 
 
+
+_GCE_METADATA_HOST = os.getenv('GCE_METADATA_HOST', os.getenv(
+        'GCE_METADATA_ROOT', "metadata.google.internal"
+    ))
+
 METADATA_ROOT = 'http://{}/computeMetadata/v1/'.format(
-    os.getenv('GCE_METADATA_ROOT', 'metadata.google.internal'))
+    _GCE_METADATA_HOST)
 METADATA_HEADERS = {'Metadata-Flavor': 'Google'}
 
 

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -173,3 +173,19 @@ class AppAssertionCredentialsTests(unittest.TestCase):
         self.assertEqual(http.requests, 1)
         expected_uri = 'http://{}/computeMetadata/v1/'.format(fake_metadata_root)
         self.assertEqual(http.uri, expected_uri)
+
+    def test_new_custom_metadata_host_from_env(self):
+        headers = {'content-type': 'application/json'}
+        http = http_mock.HttpMock(headers=headers, data='{}')
+        fake_metadata_root = 'another.metadata.service'
+        os.environ['GCE_METADATA_HOST'] = fake_metadata_root
+        reload_module(_metadata)
+        try:
+            _metadata.get(http, '')
+        finally:
+            del os.environ['GCE_METADATA_HOST']
+            reload_module(_metadata)
+        # Verify mock.
+        self.assertEqual(http.requests, 1)
+        expected_uri = 'http://{}/computeMetadata/v1/'.format(fake_metadata_root)
+        self.assertEqual(http.uri, expected_uri)


### PR DESCRIPTION
Brings the logic from https://github.com/googleapis/google-auth-library-python/pull/433 to this vendored package.