### PR TITLE
chore: remove pycrypto as its not used

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,6 @@ django
 flask
 keyring
 mock
-pycrypto>=2.6
 pyopenssl>=0.14
 python-gflags
 pyyaml

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = flake8,py27,py34,py35,gae,cover
 
 [testenv]
 basedeps = mock>=1.3.0
-           pycrypto>=2.6
            cryptography>=1.0
            pyopenssl>=0.14
            webtest
@@ -68,7 +67,6 @@ basepython =
 commands =
     {toxinidir}/scripts/run_system_tests.sh
 deps =
-    pycrypto>=2.6
     cryptography>=1.0
     pyopenssl>=0.14
 passenv = GOOGLE_* OAUTH2CLIENT_* TRAVIS* encrypted_*
@@ -79,7 +77,6 @@ basepython =
 commands =
     {toxinidir}/scripts/run_system_tests.sh
 deps =
-    pycrypto>=2.6
     cryptography>=1.0
     pyopenssl>=0.14
 passenv = {[testenv:system-tests]passenv}
@@ -89,8 +86,6 @@ basepython =
     python2.7
 commands =
     python {toxinidir}/scripts/run_gce_system_tests.py
-deps =
-    pycrypto>=2.6
 passenv = {[testenv:system-tests]passenv}
 
 [testenv:flake8]


### PR DESCRIPTION
Remove unused pycrypto dependency.

This library is listed in requirements but not used in the codebase.
It's being flagged by security scanners due to known vulnerabilities.
Removing it reduces attack surface and quietens security alerts.

